### PR TITLE
Fix typo in .travis.yml (hopefully last travis fix)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,5 @@ before_script:
 
 script:
   - diff -u <(echo -n) <(gofmt -d -s $(go list ./... | grep -v /vendor/))
-  - gometalinter ./... --vendor --dealdine 100s
+  - gometalinter ./... --vendor --deadline 100s
   - go test ./...


### PR DESCRIPTION
PR #3 intends to add `--deadline` flag. `--dealdine` is added instead.