### PR TITLE
Introduce Consumer interfaces

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -1,0 +1,24 @@
+package consumer
+
+import (
+	"context"
+	"github.com/goat-project/goat-proto-go"
+)
+
+// IPConsumer processes IpRecord-s
+type IPConsumer interface {
+	// ConsumeIps processes all ip records from specified channel and specified client id
+	ConsumeIps(ctx context.Context, id string, ips <-chan goat_grpc.IpRecord)
+}
+
+// VMConsumer processes VmRecords
+type VMConsumer interface {
+	// ConsumeVMs processes all ip records from specified channel and specified client id
+	ConsumeVms(ctx context.Context, id string, vms <-chan goat_grpc.VmRecord)
+}
+
+// StorageConsumer processes StorageRecords
+type StorageConsumer interface {
+	// ConsumeIps processes all ip records from specified channel and specified client id
+	ConsumeStorages(ctx context.Context, id string, sts <-chan goat_grpc.StorageRecord)
+}

--- a/consumer/writer.go
+++ b/consumer/writer.go
@@ -1,0 +1,35 @@
+package consumer
+
+import (
+	"context"
+	"github.com/goat-project/goat-proto-go"
+)
+
+// WriterConsumer processes accounting data by transforming them according to supplied templates and subsequently writing to a file
+type WriterConsumer struct {
+	dir          string
+	templatesDir string
+}
+
+// NewWriter creates a new WriterConsumer
+func NewWriter(dir, templatesDir string) WriterConsumer {
+	return WriterConsumer{
+		dir:          dir,
+		templatesDir: templatesDir,
+	}
+}
+
+// ConsumeIps transforms IpRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each IpRecord is written to its own file.
+func (wc WriterConsumer) ConsumeIps(ctx context.Context, id string, ips <-chan goat_grpc.IpRecord) {
+	// TODO
+}
+
+// ConsumeVms transforms VmRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each VmRecord is written to its own file.
+func (wc WriterConsumer) ConsumeVms(ctx context.Context, id string, vms <-chan goat_grpc.VmRecord) {
+	// TODO
+}
+
+// ConsumeStorages transforms StorageRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each StorageRecord is written to its own file.
+func (wc WriterConsumer) ConsumeStorages(ctx context.Context, id string, sts <-chan goat_grpc.StorageRecord) {
+	// TODO
+}

--- a/goat.go
+++ b/goat.go
@@ -48,7 +48,7 @@ func main() {
 		return
 	}
 
-	err = service.Serve(ip, port, tls, certFile, keyFile)
+	err = service.Serve(ip, port, tls, certFile, keyFile, outDir, templatesDir)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/goat.go
+++ b/goat.go
@@ -9,11 +9,13 @@ import (
 
 // CLI option names
 var (
-	ip       = flag.String("listen-ip", "127.0.0.1", "IP address to bind to")
-	port     = flag.Uint("port", 9623, "port to bind to")
-	tls      = flag.Bool("tls", false, "True uses TLS, false uses plaintext TCP")
-	certFile = flag.String("cert-file", "server.pem", "server certificate file")
-	keyFile  = flag.String("key-file", "server.key", "server key file")
+	ip           = flag.String("listen-ip", "127.0.0.1", "IP address to bind to")
+	port         = flag.Uint("port", 9623, "port to bind to")
+	tls          = flag.Bool("tls", false, "True uses TLS, false uses plaintext TCP")
+	certFile     = flag.String("cert-file", "server.pem", "server certificate file")
+	keyFile      = flag.String("key-file", "server.key", "server key file")
+	outDir       = flag.String("out-dir", "", "output directory")
+	templatesDir = flag.String("templates-dir", "", "templates directory")
 )
 
 func checkArgs() error {
@@ -25,6 +27,15 @@ func checkArgs() error {
 			return fmt.Errorf("Please specify a -key-file")
 		}
 	}
+
+	if *outDir == "" {
+		return fmt.Errorf("Please specify an -out-dir")
+	}
+
+	if *templatesDir == "" {
+		return fmt.Errorf("Please specify a -templates-dir")
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR introduces Consumer interfaces. Consumers are responsible for processing values received by importer. There is a separate interface for each accounting data record (IP, VM, Storage), so they can be implemented separately in case of need.

Apart from that, this PR adds a dummy implementation of all three interfaces called `Writer`. This will be later used to write processing results into files as desired.

This PR depends on #6. Please merge it before and I'll rebase on master. I just wanted to submit it for review.