### PR TITLE
Handle errors and done signals from consumers

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -8,17 +8,17 @@ import (
 // IPConsumer processes IpRecord-s
 type IPConsumer interface {
 	// ConsumeIps processes all ip records from specified channel and specified client id
-	ConsumeIps(ctx context.Context, id string, ips <-chan goat_grpc.IpRecord)
+	ConsumeIps(ctx context.Context, id string, ips <-chan goat_grpc.IpRecord) (DoneChannel, error)
 }
 
 // VMConsumer processes VmRecords
 type VMConsumer interface {
 	// ConsumeVMs processes all ip records from specified channel and specified client id
-	ConsumeVms(ctx context.Context, id string, vms <-chan goat_grpc.VmRecord)
+	ConsumeVms(ctx context.Context, id string, vms <-chan goat_grpc.VmRecord) (DoneChannel, error)
 }
 
 // StorageConsumer processes StorageRecords
 type StorageConsumer interface {
 	// ConsumeIps processes all ip records from specified channel and specified client id
-	ConsumeStorages(ctx context.Context, id string, sts <-chan goat_grpc.StorageRecord)
+	ConsumeStorages(ctx context.Context, id string, sts <-chan goat_grpc.StorageRecord) (DoneChannel, error)
 }

--- a/consumer/done_channel.go
+++ b/consumer/done_channel.go
@@ -1,0 +1,32 @@
+package consumer
+
+import (
+	"sync"
+)
+
+// DoneChannel represents a channel which is closed once a goroutine is done
+type DoneChannel <-chan struct{}
+
+// AndDone joins specified channels into single one. The resulting channel will be done once all channels are done.
+func AndDone(chans ...DoneChannel) DoneChannel {
+	var wg sync.WaitGroup
+
+	result := make(chan struct{})
+
+	multiplex := func(c DoneChannel) {
+		<-c
+		wg.Done()
+	}
+
+	wg.Add(len(chans))
+	for _, ch := range chans {
+		go multiplex(ch)
+	}
+
+	go func() {
+		wg.Wait()
+		close(result)
+	}()
+
+	return result
+}

--- a/consumer/writer.go
+++ b/consumer/writer.go
@@ -20,16 +20,19 @@ func NewWriter(dir, templatesDir string) WriterConsumer {
 }
 
 // ConsumeIps transforms IpRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each IpRecord is written to its own file.
-func (wc WriterConsumer) ConsumeIps(ctx context.Context, id string, ips <-chan goat_grpc.IpRecord) {
-	// TODO
+func (wc WriterConsumer) ConsumeIps(ctx context.Context, id string, ips <-chan goat_grpc.IpRecord) (DoneChannel, error) {
+	done := make(chan struct{})
+	return done, nil
 }
 
 // ConsumeVms transforms VmRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each VmRecord is written to its own file.
-func (wc WriterConsumer) ConsumeVms(ctx context.Context, id string, vms <-chan goat_grpc.VmRecord) {
-	// TODO
+func (wc WriterConsumer) ConsumeVms(ctx context.Context, id string, vms <-chan goat_grpc.VmRecord) (DoneChannel, error) {
+	done := make(chan struct{})
+	return done, nil
 }
 
 // ConsumeStorages transforms StorageRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each StorageRecord is written to its own file.
-func (wc WriterConsumer) ConsumeStorages(ctx context.Context, id string, sts <-chan goat_grpc.StorageRecord) {
-	// TODO
+func (wc WriterConsumer) ConsumeStorages(ctx context.Context, id string, sts <-chan goat_grpc.StorageRecord) (DoneChannel, error) {
+	done := make(chan struct{})
+	return done, nil
 }


### PR DESCRIPTION
This PR adds:
1. Handling of consumer startup errors. 
2. Waiting until consumers are finished before exiting the method (this prevents goroutine leaks). This is achieved by joining the `DoneChannel`s using `AndDone`. When EOF is encountered, the record channels are closed and then `Process` waits until all consumers are done. If an error occurs, all consumers are cancelled using `cancelConsumers` which uses `context`.