### PR TITLE
Add template-based implementation of consumer

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -120,7 +120,10 @@
   analyzer-version = 1
   input-imports = [
     "github.com/goat-project/goat-proto-go",
+    "github.com/golang/protobuf/ptypes/duration",
     "github.com/golang/protobuf/ptypes/empty",
+    "github.com/golang/protobuf/ptypes/timestamp",
+    "github.com/golang/protobuf/ptypes/wrappers",
     "google.golang.org/grpc",
     "google.golang.org/grpc/credentials",
   ]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -120,9 +120,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/goat-project/goat-proto-go",
-    "github.com/golang/protobuf/ptypes/duration",
     "github.com/golang/protobuf/ptypes/empty",
-    "github.com/golang/protobuf/ptypes/timestamp",
     "github.com/golang/protobuf/ptypes/wrappers",
     "google.golang.org/grpc",
     "google.golang.org/grpc/credentials",

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -5,20 +5,8 @@ import (
 	"github.com/goat-project/goat/consumer/wrapper"
 )
 
-// IPConsumer processes IpRecord-s
-type IPConsumer interface {
-	// ConsumeIps processes all ip records from specified channel and specified client id
-	ConsumeIps(ctx context.Context, id string, ips <-chan wrapper.RecordWrapper) (ResultsChannel, error)
-}
-
-// VMConsumer processes VmRecords
-type VMConsumer interface {
-	// ConsumeVMs processes all ip records from specified channel and specified client id
-	ConsumeVms(ctx context.Context, id string, vms <-chan wrapper.RecordWrapper) (ResultsChannel, error)
-}
-
-// StorageConsumer processes StorageRecords
-type StorageConsumer interface {
-	// ConsumeIps processes all ip records from specified channel and specified client id
-	ConsumeStorages(ctx context.Context, id string, sts <-chan wrapper.RecordWrapper) (ResultsChannel, error)
+// Consumer processes records
+type Consumer interface {
+	// Consume processes all records from specified channel and specified client id
+	Consume(ctx context.Context, id string, records <-chan wrapper.RecordWrapper) (ResultsChannel, error)
 }

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -2,23 +2,23 @@ package consumer
 
 import (
 	"context"
-	"github.com/goat-project/goat-proto-go"
+	"github.com/goat-project/goat/consumer/wrapper"
 )
 
 // IPConsumer processes IpRecord-s
 type IPConsumer interface {
 	// ConsumeIps processes all ip records from specified channel and specified client id
-	ConsumeIps(ctx context.Context, id string, ips <-chan goat_grpc.IpRecord) (ResultsChannel, error)
+	ConsumeIps(ctx context.Context, id string, ips <-chan wrapper.RecordWrapper) (ResultsChannel, error)
 }
 
 // VMConsumer processes VmRecords
 type VMConsumer interface {
 	// ConsumeVMs processes all ip records from specified channel and specified client id
-	ConsumeVms(ctx context.Context, id string, vms <-chan goat_grpc.VmRecord) (ResultsChannel, error)
+	ConsumeVms(ctx context.Context, id string, vms <-chan wrapper.RecordWrapper) (ResultsChannel, error)
 }
 
 // StorageConsumer processes StorageRecords
 type StorageConsumer interface {
 	// ConsumeIps processes all ip records from specified channel and specified client id
-	ConsumeStorages(ctx context.Context, id string, sts <-chan goat_grpc.StorageRecord) (ResultsChannel, error)
+	ConsumeStorages(ctx context.Context, id string, sts <-chan wrapper.RecordWrapper) (ResultsChannel, error)
 }

--- a/consumer/results_channel.go
+++ b/consumer/results_channel.go
@@ -42,6 +42,14 @@ func NewOkResult() Result {
 	}
 }
 
+// NewResultFromError creates an unsuccessful result in case specified error is not nil. If the error is nil, it creates a successful result
+func NewResultFromError(e error) Result {
+	if e != nil {
+		return NewErrorResult(e)
+	}
+	return NewOkResult()
+}
+
 // CheckResults reads all results from given results channels. When an error is encountered, onError is called with the underlying error
 func CheckResults(onError ErrHandler, chans ...ResultsChannel) {
 	var wg sync.WaitGroup

--- a/consumer/wrapper/ip_wrapper.go
+++ b/consumer/wrapper/ip_wrapper.go
@@ -1,0 +1,38 @@
+package wrapper
+
+import (
+	"github.com/goat-project/goat-proto-go"
+)
+
+type ipWrapper struct {
+	ip goat_grpc.IpRecord
+}
+
+type ipJSON struct {
+	// TODO
+}
+
+func NewIpWrapper(ip goat_grpc.IpRecord) RecordWrapper {
+	return ipWrapper{
+		ip: ip,
+	}
+
+}
+
+func (iw ipWrapper) Filename() string {
+	// TODO
+	return ""
+}
+
+func (iw ipWrapper) AsXML() interface{} {
+	return iw.ip
+}
+
+func (iw ipWrapper) AsJSON() interface{} {
+	// TODO
+	return ipJSON{}
+}
+
+func (iw ipWrapper) AsTemplate() interface{} {
+	return iw.ip
+}

--- a/consumer/wrapper/ip_wrapper.go
+++ b/consumer/wrapper/ip_wrapper.go
@@ -12,7 +12,8 @@ type ipJSON struct {
 	// TODO
 }
 
-func NewIpWrapper(ip goat_grpc.IpRecord) RecordWrapper {
+// NewIPWrapper wraps given ip in a RecordWrapper
+func NewIPWrapper(ip goat_grpc.IpRecord) RecordWrapper {
 	return ipWrapper{
 		ip: ip,
 	}

--- a/consumer/wrapper/storage_wrapper.go
+++ b/consumer/wrapper/storage_wrapper.go
@@ -1,0 +1,36 @@
+package wrapper
+
+import (
+	"github.com/goat-project/goat-proto-go"
+)
+
+type storageWrapper struct {
+	st goat_grpc.StorageRecord
+}
+
+type storageXML struct {
+}
+
+func NewStorageWrapper(st goat_grpc.StorageRecord) RecordWrapper {
+	return storageWrapper{
+		st: st,
+	}
+}
+
+func (sw storageWrapper) Filename() string {
+	return sw.st.GetRecordID()
+}
+
+func (sw storageWrapper) AsXML() interface{} {
+	// TODO
+	return storageXML{}
+}
+
+func (sw storageWrapper) AsJSON() interface{} {
+	return sw.st
+}
+
+func (sw storageWrapper) AsTemplate() interface{} {
+	return sw.st
+
+}

--- a/consumer/wrapper/storage_wrapper.go
+++ b/consumer/wrapper/storage_wrapper.go
@@ -11,6 +11,7 @@ type storageWrapper struct {
 type storageXML struct {
 }
 
+// NewStorageWrapper wraps given storage in a RecordWrapper
 func NewStorageWrapper(st goat_grpc.StorageRecord) RecordWrapper {
 	return storageWrapper{
 		st: st,

--- a/consumer/wrapper/vm_wrapper.go
+++ b/consumer/wrapper/vm_wrapper.go
@@ -12,7 +12,8 @@ type vmTemplate struct {
 	// TODO
 }
 
-func NewVmWrapper(vm goat_grpc.VmRecord) RecordWrapper {
+// NewVMWrapper wraps given vm in a RecordWrapper
+func NewVMWrapper(vm goat_grpc.VmRecord) RecordWrapper {
 	return vmWrapper{
 		vm: vm,
 	}

--- a/consumer/wrapper/vm_wrapper.go
+++ b/consumer/wrapper/vm_wrapper.go
@@ -2,6 +2,9 @@ package wrapper
 
 import (
 	"github.com/goat-project/goat-proto-go"
+	duration "github.com/golang/protobuf/ptypes/duration"
+	timestamp "github.com/golang/protobuf/ptypes/timestamp"
+	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 )
 
 type vmWrapper struct {
@@ -9,7 +12,32 @@ type vmWrapper struct {
 }
 
 type vmTemplate struct {
-	// TODO
+	VMUUID              string
+	SiteName            string
+	CloudComputeService *string
+	MachineName         string
+	LocalUserID         *string
+	LocalGroupID        *string
+	GlobalUserName      *string
+	Fqan                *string
+	Status              *string
+	StartTime           *string
+	EndTime             *string
+	SuspendDuration     *string
+	WallDuration        *string
+	CPUDuration         *string
+	CPUCount            uint32
+	NetworkType         *string
+	NetworkInbound      *uint64
+	NetworkOutbound     *uint64
+	PublicIPCount       *uint64
+	Memory              *uint64
+	Disk                *uint64
+	BenchmarkType       *string
+	Benchmark           *float32
+	StorageRecordID     *string
+	ImageID             *string
+	CloudType           *string
 }
 
 // NewVMWrapper wraps given vm in a RecordWrapper
@@ -31,7 +59,84 @@ func (vw vmWrapper) AsXML() interface{} {
 	return vw.vm
 }
 
+func s(wr *wrappers.StringValue) *string {
+	if wr == nil {
+		return nil
+	}
+
+	result := new(string)
+	*result = wr.GetValue()
+
+	return result
+}
+
+func u64(wr *wrappers.UInt64Value) *uint64 {
+	if wr == nil {
+		return nil
+	}
+	result := new(uint64)
+	*result = wr.GetValue()
+
+	return result
+}
+
+func f32(wr *wrappers.FloatValue) *float32 {
+	if wr == nil {
+		return nil
+	}
+	result := new(float32)
+	*result = wr.GetValue()
+
+	return result
+}
+
+func t(wr *timestamp.Timestamp) *string {
+	if wr == nil {
+		return nil
+	}
+
+	result := new(string)
+	*result = wr.String()
+	return result
+}
+
+func d(wr *duration.Duration) *string {
+	if wr == nil {
+		return nil
+	}
+
+	result := new(string)
+	*result = wr.String()
+	return result
+}
+
 func (vw vmWrapper) AsTemplate() interface{} {
-	// TODO
-	return vmTemplate{}
+	return vmTemplate{
+		VMUUID:              vw.vm.GetVmUuid(),
+		SiteName:            vw.vm.GetSiteName(),
+		CloudComputeService: s(vw.vm.GetCloudComputeService()),
+		MachineName:         vw.vm.GetMachineName(),
+		LocalUserID:         s(vw.vm.GetLocalUserId()),
+		LocalGroupID:        s(vw.vm.GetLocalGroupId()),
+		GlobalUserName:      s(vw.vm.GetGlobalUserName()),
+		Fqan:                s(vw.vm.GetFqan()),
+		Status:              s(vw.vm.GetStatus()),
+		StartTime:           t(vw.vm.GetStartTime()),
+		EndTime:             t(vw.vm.GetEndTime()),
+		SuspendDuration:     d(vw.vm.GetSuspendDuration()),
+		WallDuration:        d(vw.vm.GetWallDuration()),
+		CPUDuration:         d(vw.vm.GetCpuDuration()),
+		CPUCount:            vw.vm.GetCpuCount(),
+		NetworkType:         s(vw.vm.GetNetworkType()),
+		NetworkInbound:      u64(vw.vm.GetNetworkInbound()),
+		NetworkOutbound:     u64(vw.vm.GetNetworkOutbound()),
+		PublicIPCount:       u64(vw.vm.GetPublicIpCount()),
+		Memory:              u64(vw.vm.GetMemory()),
+		Disk:                u64(vw.vm.GetDisk()),
+		BenchmarkType:       s(vw.vm.GetBenchmarkType()),
+		Benchmark:           f32(vw.vm.GetBenchmark()),
+		StorageRecordID:     s(vw.vm.GetStorageRecordId()),
+		ImageID:             s(vw.vm.GetImageId()),
+		CloudType:           s(vw.vm.GetCloudType()),
+	}
 }

--- a/consumer/wrapper/vm_wrapper.go
+++ b/consumer/wrapper/vm_wrapper.go
@@ -1,0 +1,36 @@
+package wrapper
+
+import (
+	"github.com/goat-project/goat-proto-go"
+)
+
+type vmWrapper struct {
+	vm goat_grpc.VmRecord
+}
+
+type vmTemplate struct {
+	// TODO
+}
+
+func NewVmWrapper(vm goat_grpc.VmRecord) RecordWrapper {
+	return vmWrapper{
+		vm: vm,
+	}
+}
+
+func (vw vmWrapper) Filename() string {
+	return vw.vm.GetVmUuid()
+}
+
+func (vw vmWrapper) AsJSON() interface{} {
+	return vw.vm
+}
+
+func (vw vmWrapper) AsXML() interface{} {
+	return vw.vm
+}
+
+func (vw vmWrapper) AsTemplate() interface{} {
+	// TODO
+	return vmTemplate{}
+}

--- a/consumer/wrapper/vm_wrapper.go
+++ b/consumer/wrapper/vm_wrapper.go
@@ -1,9 +1,8 @@
 package wrapper
 
 import (
+	"fmt"
 	"github.com/goat-project/goat-proto-go"
-	duration "github.com/golang/protobuf/ptypes/duration"
-	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 )
 
@@ -59,17 +58,6 @@ func (vw vmWrapper) AsXML() interface{} {
 	return vw.vm
 }
 
-func s(wr *wrappers.StringValue) *string {
-	if wr == nil {
-		return nil
-	}
-
-	result := new(string)
-	*result = wr.GetValue()
-
-	return result
-}
-
 func u64(wr *wrappers.UInt64Value) *uint64 {
 	if wr == nil {
 		return nil
@@ -90,17 +78,7 @@ func f32(wr *wrappers.FloatValue) *float32 {
 	return result
 }
 
-func t(wr *timestamp.Timestamp) *string {
-	if wr == nil {
-		return nil
-	}
-
-	result := new(string)
-	*result = wr.String()
-	return result
-}
-
-func d(wr *duration.Duration) *string {
+func s(wr fmt.Stringer) *string {
 	if wr == nil {
 		return nil
 	}
@@ -121,11 +99,11 @@ func (vw vmWrapper) AsTemplate() interface{} {
 		GlobalUserName:      s(vw.vm.GetGlobalUserName()),
 		Fqan:                s(vw.vm.GetFqan()),
 		Status:              s(vw.vm.GetStatus()),
-		StartTime:           t(vw.vm.GetStartTime()),
-		EndTime:             t(vw.vm.GetEndTime()),
-		SuspendDuration:     d(vw.vm.GetSuspendDuration()),
-		WallDuration:        d(vw.vm.GetWallDuration()),
-		CPUDuration:         d(vw.vm.GetCpuDuration()),
+		StartTime:           s(vw.vm.GetStartTime()),
+		EndTime:             s(vw.vm.GetEndTime()),
+		SuspendDuration:     s(vw.vm.GetSuspendDuration()),
+		WallDuration:        s(vw.vm.GetWallDuration()),
+		CPUDuration:         s(vw.vm.GetCpuDuration()),
 		CPUCount:            vw.vm.GetCpuCount(),
 		NetworkType:         s(vw.vm.GetNetworkType()),
 		NetworkInbound:      u64(vw.vm.GetNetworkInbound()),

--- a/consumer/wrapper/wrapper.go
+++ b/consumer/wrapper/wrapper.go
@@ -1,0 +1,32 @@
+package wrapper
+
+import (
+	"github.com/goat-project/goat-proto-go"
+)
+
+// RecordWrapper is an interface to wrap record types
+type RecordWrapper interface {
+	// Filename returns name of file this should be saved in WITHOUT extension
+	Filename() string
+
+	// AsJson returns an annotated structure that can be serialized to JSON
+	AsJSON() interface{}
+
+	// AsXml returns an annotated structure that can be serialized to XML
+	AsXML() interface{}
+
+	// AsAPEL returns a structure that can be serialized via template
+	AsTemplate() interface{}
+}
+
+func WrapVm(vm goat_grpc.VmRecord) RecordWrapper {
+	return NewVmWrapper(vm)
+}
+
+func WrapIp(ip goat_grpc.IpRecord) RecordWrapper {
+	return NewIpWrapper(ip)
+}
+
+func WrapStorage(st goat_grpc.StorageRecord) RecordWrapper {
+	return NewStorageWrapper(st)
+}

--- a/consumer/wrapper/wrapper.go
+++ b/consumer/wrapper/wrapper.go
@@ -19,14 +19,17 @@ type RecordWrapper interface {
 	AsTemplate() interface{}
 }
 
-func WrapVm(vm goat_grpc.VmRecord) RecordWrapper {
-	return NewVmWrapper(vm)
+// WrapVM wraps given vm in a RecordWrapper
+func WrapVM(vm goat_grpc.VmRecord) RecordWrapper {
+	return NewVMWrapper(vm)
 }
 
-func WrapIp(ip goat_grpc.IpRecord) RecordWrapper {
-	return NewIpWrapper(ip)
+// WrapIP wraps given ip in a RecordWrapper
+func WrapIP(ip goat_grpc.IpRecord) RecordWrapper {
+	return NewIPWrapper(ip)
 }
 
+// WrapStorage wraps given storage in a RecordWrapper
 func WrapStorage(st goat_grpc.StorageRecord) RecordWrapper {
 	return NewStorageWrapper(st)
 }

--- a/consumer/wrapper/wrapper.go
+++ b/consumer/wrapper/wrapper.go
@@ -15,7 +15,7 @@ type RecordWrapper interface {
 	// AsXml returns an annotated structure that can be serialized to XML
 	AsXML() interface{}
 
-	// AsAPEL returns a structure that can be serialized via template
+	// AsTemplate returns a structure that can be serialized via template
 	AsTemplate() interface{}
 }
 

--- a/consumer/writer.go
+++ b/consumer/writer.go
@@ -2,13 +2,18 @@ package consumer
 
 import (
 	"context"
-	"github.com/goat-project/goat-proto-go"
+	"github.com/goat-project/goat/consumer/wrapper"
+	"io"
+	"os"
+	"path"
+	"text/template"
 )
 
 // WriterConsumer processes accounting data by transforming them according to supplied templates and subsequently writing to a file
 type WriterConsumer struct {
 	dir          string
 	templatesDir string
+	template     *template.Template
 }
 
 // NewWriter creates a new WriterConsumer
@@ -19,20 +24,88 @@ func NewWriter(dir, templatesDir string) WriterConsumer {
 	}
 }
 
-// ConsumeIps transforms IpRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each IpRecord is written to its own file.
-func (wc WriterConsumer) ConsumeIps(ctx context.Context, id string, ips <-chan goat_grpc.IpRecord) (ResultsChannel, error) {
+func ensureDirectoryExists(path string) error {
+	err := os.MkdirAll(path, os.ModeDir)
+	if err != nil && err != os.ErrExist {
+		return err
+	}
+
+	return nil
+}
+
+func (wc *WriterConsumer) initTemplates() error {
+	if wc.template != nil {
+		return nil
+	}
+	template, err := template.ParseGlob(path.Join(wc.templatesDir, "*.tmpl"))
+	wc.template = template
+	return err
+}
+
+func (wc WriterConsumer) processTo(record interface{}, wr io.Writer) error {
+	return wc.template.Execute(wr, record)
+}
+
+func (wc WriterConsumer) write(id string, rw wrapper.RecordWrapper) error {
+
+	file, err := os.Open(path.Join(path.Join(wc.dir, id), rw.Filename()))
+	defer func() {
+		cerr := file.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	if err != nil {
+		return err
+	}
+
+	if err = wc.processTo(rw.AsTemplate(), file); err != nil {
+		return err
+	}
+
+	return err
+}
+
+func (wc WriterConsumer) consume(ctx context.Context, id string, records <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
 	res := make(chan Result)
+
+	if err := ensureDirectoryExists(path.Join(wc.dir, id)); err != nil {
+		return nil, err
+	}
+
+	if err := wc.initTemplates(); err != nil {
+		return nil, err
+	}
+
+	go func() {
+		defer close(res)
+
+		for {
+			select {
+			case rec := <-records:
+				res <- NewResultFromError(wc.write(id, rec))
+			case <-ctx.Done():
+				return
+			}
+		}
+
+	}()
+
 	return res, nil
 }
 
-// ConsumeVms transforms VmRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each VmRecord is written to its own file.
-func (wc WriterConsumer) ConsumeVms(ctx context.Context, id string, vms <-chan goat_grpc.VmRecord) (ResultsChannel, error) {
-	res := make(chan Result)
-	return res, nil
+// ConsumeIps transforms IpRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each IpRecord is written into its own file.
+func (wc WriterConsumer) ConsumeIps(ctx context.Context, id string, ips <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
+	return wc.consume(ctx, id, ips)
 }
 
-// ConsumeStorages transforms StorageRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each StorageRecord is written to its own file.
-func (wc WriterConsumer) ConsumeStorages(ctx context.Context, id string, sts <-chan goat_grpc.StorageRecord) (ResultsChannel, error) {
-	res := make(chan Result)
-	return res, nil
+// ConsumeVms transforms VmRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each VmRecord is written into its own file.
+func (wc WriterConsumer) ConsumeVms(ctx context.Context, id string, vms <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
+	return wc.consume(ctx, id, vms)
+}
+
+// ConsumeStorages transforms StorageRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each StorageRecord is written into its own file.
+func (wc WriterConsumer) ConsumeStorages(ctx context.Context, id string, sts <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
+	return wc.consume(ctx, id, sts)
 }

--- a/consumer/writer.go
+++ b/consumer/writer.go
@@ -67,7 +67,8 @@ func (wc WriterConsumer) write(id string, rw wrapper.RecordWrapper) error {
 	return err
 }
 
-func (wc WriterConsumer) consume(ctx context.Context, id string, records <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
+// Consume transforms records into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each record is written into its own file.
+func (wc WriterConsumer) Consume(ctx context.Context, id string, records <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
 	res := make(chan Result)
 
 	if err := ensureDirectoryExists(path.Join(wc.dir, id)); err != nil {
@@ -93,19 +94,4 @@ func (wc WriterConsumer) consume(ctx context.Context, id string, records <-chan 
 	}()
 
 	return res, nil
-}
-
-// ConsumeIps transforms IpRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each IpRecord is written into its own file.
-func (wc WriterConsumer) ConsumeIps(ctx context.Context, id string, ips <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
-	return wc.consume(ctx, id, ips)
-}
-
-// ConsumeVms transforms VmRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each VmRecord is written into its own file.
-func (wc WriterConsumer) ConsumeVms(ctx context.Context, id string, vms <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
-	return wc.consume(ctx, id, vms)
-}
-
-// ConsumeStorages transforms StorageRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each StorageRecord is written into its own file.
-func (wc WriterConsumer) ConsumeStorages(ctx context.Context, id string, sts <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
-	return wc.consume(ctx, id, sts)
 }

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/goat-project/goat-proto-go"
 	"github.com/goat-project/goat/consumer"
+	"github.com/goat-project/goat/consumer/wrapper"
 	"github.com/golang/protobuf/ptypes/empty"
 	"io"
 )
@@ -59,9 +60,9 @@ func (asi AccountingServiceImpl) Process(stream goat_grpc.AccountingService_Proc
 	defer cancelConsumers()
 
 	// prepare channels for individual data types
-	vms := make(chan goat_grpc.VmRecord)
-	ips := make(chan goat_grpc.IpRecord)
-	storages := make(chan goat_grpc.StorageRecord)
+	vms := make(chan wrapper.RecordWrapper)
+	ips := make(chan wrapper.RecordWrapper)
+	storages := make(chan wrapper.RecordWrapper)
 
 	results1, err := asi.vmConsumer.ConsumeVms(consumerContext, id, vms)
 	if err != nil {
@@ -100,11 +101,11 @@ func (asi AccountingServiceImpl) Process(stream goat_grpc.AccountingService_Proc
 		case *goat_grpc.AccountingData_Identifier:
 			return ErrNonFirstClientIdentifier
 		case *goat_grpc.AccountingData_Vm:
-			vms <- *data.GetVm()
+			vms <- wrapper.WrapVm(*data.GetVm())
 		case *goat_grpc.AccountingData_Ip:
-			ips <- *data.GetIp()
+			ips <- wrapper.WrapIp(*data.GetIp())
 		case *goat_grpc.AccountingData_Storage:
-			storages <- *data.GetStorage()
+			storages <- wrapper.WrapStorage(*data.GetStorage())
 		default:
 			return ErrUnknownMessageType
 		}

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -101,9 +101,9 @@ func (asi AccountingServiceImpl) Process(stream goat_grpc.AccountingService_Proc
 		case *goat_grpc.AccountingData_Identifier:
 			return ErrNonFirstClientIdentifier
 		case *goat_grpc.AccountingData_Vm:
-			vms <- wrapper.WrapVm(*data.GetVm())
+			vms <- wrapper.WrapVM(*data.GetVm())
 		case *goat_grpc.AccountingData_Ip:
-			ips <- wrapper.WrapIp(*data.GetIp())
+			ips <- wrapper.WrapIP(*data.GetIp())
 		case *goat_grpc.AccountingData_Storage:
 			storages <- wrapper.WrapStorage(*data.GetStorage())
 		default:

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -21,13 +21,13 @@ var (
 
 // AccountingServiceImpl implements goat_grpc.AccountingService server
 type AccountingServiceImpl struct {
-	vmConsumer      consumer.VMConsumer
-	ipConsumer      consumer.IPConsumer
-	storageConsumer consumer.StorageConsumer
+	vmConsumer      consumer.Consumer
+	ipConsumer      consumer.Consumer
+	storageConsumer consumer.Consumer
 }
 
 // NewAccountingServiceImpl creates a grpc server that sends received data to given channels and uses clientIdentifierValidator to validate client identifiers
-func NewAccountingServiceImpl(vmConsumer consumer.VMConsumer, ipConsumer consumer.IPConsumer, storageConsumer consumer.StorageConsumer) AccountingServiceImpl {
+func NewAccountingServiceImpl(vmConsumer consumer.Consumer, ipConsumer consumer.Consumer, storageConsumer consumer.Consumer) AccountingServiceImpl {
 	return AccountingServiceImpl{
 		vmConsumer:      vmConsumer,
 		ipConsumer:      ipConsumer,
@@ -64,17 +64,17 @@ func (asi AccountingServiceImpl) Process(stream goat_grpc.AccountingService_Proc
 	ips := make(chan wrapper.RecordWrapper)
 	storages := make(chan wrapper.RecordWrapper)
 
-	results1, err := asi.vmConsumer.ConsumeVms(consumerContext, id, vms)
+	results1, err := asi.vmConsumer.Consume(consumerContext, id, vms)
 	if err != nil {
 		return err
 	}
 
-	results2, err := asi.ipConsumer.ConsumeIps(consumerContext, id, ips)
+	results2, err := asi.ipConsumer.Consume(consumerContext, id, ips)
 	if err != nil {
 		return err
 	}
 
-	results3, err := asi.storageConsumer.ConsumeStorages(consumerContext, id, storages)
+	results3, err := asi.storageConsumer.Consume(consumerContext, id, storages)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR adds a template-based implementation of consumer called `Writer`. Currently, `Writer` outputs each storage/ip/vm into a separate file. IP addresses don't have an ID yet, so their filename isn't set.