### PR TITLE
Add wrapper structures, implement VM to template

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -120,7 +120,10 @@
   analyzer-version = 1
   input-imports = [
     "github.com/goat-project/goat-proto-go",
+    "github.com/golang/protobuf/ptypes/duration",
     "github.com/golang/protobuf/ptypes/empty",
+    "github.com/golang/protobuf/ptypes/timestamp",
+    "github.com/golang/protobuf/ptypes/wrappers",
     "google.golang.org/grpc",
     "google.golang.org/grpc/credentials",
   ]

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -120,9 +120,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/goat-project/goat-proto-go",
-    "github.com/golang/protobuf/ptypes/duration",
     "github.com/golang/protobuf/ptypes/empty",
-    "github.com/golang/protobuf/ptypes/timestamp",
     "github.com/golang/protobuf/ptypes/wrappers",
     "google.golang.org/grpc",
     "google.golang.org/grpc/credentials",

--- a/consumer/wrapper/ip_wrapper.go
+++ b/consumer/wrapper/ip_wrapper.go
@@ -1,0 +1,39 @@
+package wrapper
+
+import (
+	"github.com/goat-project/goat-proto-go"
+)
+
+type ipWrapper struct {
+	ip goat_grpc.IpRecord
+}
+
+type ipJSON struct {
+	// TODO
+}
+
+// NewIPWrapper wraps given ip in a RecordWrapper
+func NewIPWrapper(ip goat_grpc.IpRecord) RecordWrapper {
+	return ipWrapper{
+		ip: ip,
+	}
+
+}
+
+func (iw ipWrapper) Filename() string {
+	// TODO
+	return ""
+}
+
+func (iw ipWrapper) AsXML() interface{} {
+	return iw.ip
+}
+
+func (iw ipWrapper) AsJSON() interface{} {
+	// TODO
+	return ipJSON{}
+}
+
+func (iw ipWrapper) AsTemplate() interface{} {
+	return iw.ip
+}

--- a/consumer/wrapper/ip_wrapper.go
+++ b/consumer/wrapper/ip_wrapper.go
@@ -25,15 +25,15 @@ func (iw ipWrapper) Filename() string {
 	return ""
 }
 
-func (iw ipWrapper) AsXML() interface{} {
-	return iw.ip
+func (iw ipWrapper) AsXML() (interface{}, error) {
+	return nil, ErrNotImplemented
 }
 
-func (iw ipWrapper) AsJSON() interface{} {
+func (iw ipWrapper) AsJSON() (interface{}, error) {
 	// TODO
-	return ipJSON{}
+	return ipJSON{}, nil
 }
 
-func (iw ipWrapper) AsTemplate() interface{} {
-	return iw.ip
+func (iw ipWrapper) AsTemplate() (interface{}, error) {
+	return nil, ErrNotImplemented
 }

--- a/consumer/wrapper/storage_wrapper.go
+++ b/consumer/wrapper/storage_wrapper.go
@@ -1,0 +1,37 @@
+package wrapper
+
+import (
+	"github.com/goat-project/goat-proto-go"
+)
+
+type storageWrapper struct {
+	st goat_grpc.StorageRecord
+}
+
+type storageXML struct {
+}
+
+// NewStorageWrapper wraps given storage in a RecordWrapper
+func NewStorageWrapper(st goat_grpc.StorageRecord) RecordWrapper {
+	return storageWrapper{
+		st: st,
+	}
+}
+
+func (sw storageWrapper) Filename() string {
+	return sw.st.GetRecordID()
+}
+
+func (sw storageWrapper) AsXML() interface{} {
+	// TODO
+	return storageXML{}
+}
+
+func (sw storageWrapper) AsJSON() interface{} {
+	return sw.st
+}
+
+func (sw storageWrapper) AsTemplate() interface{} {
+	return sw.st
+
+}

--- a/consumer/wrapper/storage_wrapper.go
+++ b/consumer/wrapper/storage_wrapper.go
@@ -22,16 +22,16 @@ func (sw storageWrapper) Filename() string {
 	return sw.st.GetRecordID()
 }
 
-func (sw storageWrapper) AsXML() interface{} {
+func (sw storageWrapper) AsXML() (interface{}, error) {
 	// TODO
-	return storageXML{}
+	return storageXML{}, nil
 }
 
-func (sw storageWrapper) AsJSON() interface{} {
-	return sw.st
+func (sw storageWrapper) AsJSON() (interface{}, error) {
+	return nil, ErrNotImplemented
 }
 
-func (sw storageWrapper) AsTemplate() interface{} {
-	return sw.st
+func (sw storageWrapper) AsTemplate() (interface{}, error) {
+	return nil, ErrNotImplemented
 
 }

--- a/consumer/wrapper/vm_wrapper.go
+++ b/consumer/wrapper/vm_wrapper.go
@@ -2,6 +2,9 @@ package wrapper
 
 import (
 	"github.com/goat-project/goat-proto-go"
+	duration "github.com/golang/protobuf/ptypes/duration"
+	timestamp "github.com/golang/protobuf/ptypes/timestamp"
+	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 )
 
 type vmWrapper struct {
@@ -9,7 +12,32 @@ type vmWrapper struct {
 }
 
 type vmTemplate struct {
-	// TODO
+	VMUUID              string
+	SiteName            string
+	CloudComputeService *string
+	MachineName         string
+	LocalUserID         *string
+	LocalGroupID        *string
+	GlobalUserName      *string
+	Fqan                *string
+	Status              *string
+	StartTime           *string
+	EndTime             *string
+	SuspendDuration     *string
+	WallDuration        *string
+	CPUDuration         *string
+	CPUCount            uint32
+	NetworkType         *string
+	NetworkInbound      *uint64
+	NetworkOutbound     *uint64
+	PublicIPCount       *uint64
+	Memory              *uint64
+	Disk                *uint64
+	BenchmarkType       *string
+	Benchmark           *float32
+	StorageRecordID     *string
+	ImageID             *string
+	CloudType           *string
 }
 
 // NewVMWrapper wraps given vm in a RecordWrapper
@@ -31,7 +59,84 @@ func (vw vmWrapper) AsXML() interface{} {
 	return vw.vm
 }
 
+func s(wr *wrappers.StringValue) *string {
+	if wr == nil {
+		return nil
+	}
+
+	result := new(string)
+	*result = wr.GetValue()
+
+	return result
+}
+
+func u64(wr *wrappers.UInt64Value) *uint64 {
+	if wr == nil {
+		return nil
+	}
+	result := new(uint64)
+	*result = wr.GetValue()
+
+	return result
+}
+
+func f32(wr *wrappers.FloatValue) *float32 {
+	if wr == nil {
+		return nil
+	}
+	result := new(float32)
+	*result = wr.GetValue()
+
+	return result
+}
+
+func t(wr *timestamp.Timestamp) *string {
+	if wr == nil {
+		return nil
+	}
+
+	result := new(string)
+	*result = wr.String()
+	return result
+}
+
+func d(wr *duration.Duration) *string {
+	if wr == nil {
+		return nil
+	}
+
+	result := new(string)
+	*result = wr.String()
+	return result
+}
+
 func (vw vmWrapper) AsTemplate() interface{} {
-	// TODO
-	return vmTemplate{}
+	return vmTemplate{
+		VMUUID:              vw.vm.GetVmUuid(),
+		SiteName:            vw.vm.GetSiteName(),
+		CloudComputeService: s(vw.vm.GetCloudComputeService()),
+		MachineName:         vw.vm.GetMachineName(),
+		LocalUserID:         s(vw.vm.GetLocalUserId()),
+		LocalGroupID:        s(vw.vm.GetLocalGroupId()),
+		GlobalUserName:      s(vw.vm.GetGlobalUserName()),
+		Fqan:                s(vw.vm.GetFqan()),
+		Status:              s(vw.vm.GetStatus()),
+		StartTime:           t(vw.vm.GetStartTime()),
+		EndTime:             t(vw.vm.GetEndTime()),
+		SuspendDuration:     d(vw.vm.GetSuspendDuration()),
+		WallDuration:        d(vw.vm.GetWallDuration()),
+		CPUDuration:         d(vw.vm.GetCpuDuration()),
+		CPUCount:            vw.vm.GetCpuCount(),
+		NetworkType:         s(vw.vm.GetNetworkType()),
+		NetworkInbound:      u64(vw.vm.GetNetworkInbound()),
+		NetworkOutbound:     u64(vw.vm.GetNetworkOutbound()),
+		PublicIPCount:       u64(vw.vm.GetPublicIpCount()),
+		Memory:              u64(vw.vm.GetMemory()),
+		Disk:                u64(vw.vm.GetDisk()),
+		BenchmarkType:       s(vw.vm.GetBenchmarkType()),
+		Benchmark:           f32(vw.vm.GetBenchmark()),
+		StorageRecordID:     s(vw.vm.GetStorageRecordId()),
+		ImageID:             s(vw.vm.GetImageId()),
+		CloudType:           s(vw.vm.GetCloudType()),
+	}
 }

--- a/consumer/wrapper/vm_wrapper.go
+++ b/consumer/wrapper/vm_wrapper.go
@@ -50,12 +50,12 @@ func (vw vmWrapper) Filename() string {
 	return vw.vm.GetVmUuid()
 }
 
-func (vw vmWrapper) AsJSON() interface{} {
-	return vw.vm
+func (vw vmWrapper) AsJSON() (interface{}, error) {
+	return nil, ErrNotImplemented
 }
 
-func (vw vmWrapper) AsXML() interface{} {
-	return vw.vm
+func (vw vmWrapper) AsXML() (interface{}, error) {
+	return nil, ErrNotImplemented
 }
 
 func u64(wr *wrappers.UInt64Value) *uint64 {
@@ -88,7 +88,7 @@ func s(wr fmt.Stringer) *string {
 	return result
 }
 
-func (vw vmWrapper) AsTemplate() interface{} {
+func (vw vmWrapper) AsTemplate() (interface{}, error) {
 	return vmTemplate{
 		VMUUID:              vw.vm.GetVmUuid(),
 		SiteName:            vw.vm.GetSiteName(),
@@ -102,8 +102,8 @@ func (vw vmWrapper) AsTemplate() interface{} {
 		StartTime:           s(vw.vm.GetStartTime()),
 		EndTime:             s(vw.vm.GetEndTime()),
 		SuspendDuration:     s(vw.vm.GetSuspendDuration()),
-		WallDuration:        s(vw.vm.GetWallDuration()),
 		CPUDuration:         s(vw.vm.GetCpuDuration()),
+		WallDuration:        s(vw.vm.GetWallDuration()),
 		CPUCount:            vw.vm.GetCpuCount(),
 		NetworkType:         s(vw.vm.GetNetworkType()),
 		NetworkInbound:      u64(vw.vm.GetNetworkInbound()),
@@ -116,5 +116,5 @@ func (vw vmWrapper) AsTemplate() interface{} {
 		StorageRecordID:     s(vw.vm.GetStorageRecordId()),
 		ImageID:             s(vw.vm.GetImageId()),
 		CloudType:           s(vw.vm.GetCloudType()),
-	}
+	}, nil
 }

--- a/consumer/wrapper/vm_wrapper.go
+++ b/consumer/wrapper/vm_wrapper.go
@@ -1,0 +1,37 @@
+package wrapper
+
+import (
+	"github.com/goat-project/goat-proto-go"
+)
+
+type vmWrapper struct {
+	vm goat_grpc.VmRecord
+}
+
+type vmTemplate struct {
+	// TODO
+}
+
+// NewVMWrapper wraps given vm in a RecordWrapper
+func NewVMWrapper(vm goat_grpc.VmRecord) RecordWrapper {
+	return vmWrapper{
+		vm: vm,
+	}
+}
+
+func (vw vmWrapper) Filename() string {
+	return vw.vm.GetVmUuid()
+}
+
+func (vw vmWrapper) AsJSON() interface{} {
+	return vw.vm
+}
+
+func (vw vmWrapper) AsXML() interface{} {
+	return vw.vm
+}
+
+func (vw vmWrapper) AsTemplate() interface{} {
+	// TODO
+	return vmTemplate{}
+}

--- a/consumer/wrapper/vm_wrapper.go
+++ b/consumer/wrapper/vm_wrapper.go
@@ -1,9 +1,8 @@
 package wrapper
 
 import (
+	"fmt"
 	"github.com/goat-project/goat-proto-go"
-	duration "github.com/golang/protobuf/ptypes/duration"
-	timestamp "github.com/golang/protobuf/ptypes/timestamp"
 	wrappers "github.com/golang/protobuf/ptypes/wrappers"
 )
 
@@ -59,17 +58,6 @@ func (vw vmWrapper) AsXML() interface{} {
 	return vw.vm
 }
 
-func s(wr *wrappers.StringValue) *string {
-	if wr == nil {
-		return nil
-	}
-
-	result := new(string)
-	*result = wr.GetValue()
-
-	return result
-}
-
 func u64(wr *wrappers.UInt64Value) *uint64 {
 	if wr == nil {
 		return nil
@@ -90,17 +78,7 @@ func f32(wr *wrappers.FloatValue) *float32 {
 	return result
 }
 
-func t(wr *timestamp.Timestamp) *string {
-	if wr == nil {
-		return nil
-	}
-
-	result := new(string)
-	*result = wr.String()
-	return result
-}
-
-func d(wr *duration.Duration) *string {
+func s(wr fmt.Stringer) *string {
 	if wr == nil {
 		return nil
 	}
@@ -121,11 +99,11 @@ func (vw vmWrapper) AsTemplate() interface{} {
 		GlobalUserName:      s(vw.vm.GetGlobalUserName()),
 		Fqan:                s(vw.vm.GetFqan()),
 		Status:              s(vw.vm.GetStatus()),
-		StartTime:           t(vw.vm.GetStartTime()),
-		EndTime:             t(vw.vm.GetEndTime()),
-		SuspendDuration:     d(vw.vm.GetSuspendDuration()),
-		WallDuration:        d(vw.vm.GetWallDuration()),
-		CPUDuration:         d(vw.vm.GetCpuDuration()),
+		StartTime:           s(vw.vm.GetStartTime()),
+		EndTime:             s(vw.vm.GetEndTime()),
+		SuspendDuration:     s(vw.vm.GetSuspendDuration()),
+		WallDuration:        s(vw.vm.GetWallDuration()),
+		CPUDuration:         s(vw.vm.GetCpuDuration()),
 		CPUCount:            vw.vm.GetCpuCount(),
 		NetworkType:         s(vw.vm.GetNetworkType()),
 		NetworkInbound:      u64(vw.vm.GetNetworkInbound()),

--- a/consumer/wrapper/wrapper.go
+++ b/consumer/wrapper/wrapper.go
@@ -1,7 +1,13 @@
 package wrapper
 
 import (
+	"errors"
 	"github.com/goat-project/goat-proto-go"
+)
+
+var (
+	// ErrNotImplemented signals that the called method is not implemented
+	ErrNotImplemented = errors.New("Not implemented")
 )
 
 // RecordWrapper is an interface to wrap record types
@@ -9,14 +15,14 @@ type RecordWrapper interface {
 	// Filename returns name of file this should be saved in WITHOUT extension
 	Filename() string
 
-	// AsJson returns an annotated structure that can be serialized to JSON
-	AsJSON() interface{}
+	// AsJSON returns an annotated structure that can be serialized to JSON. ErrNotImplemented is returned if the operation is not implemented
+	AsJSON() (interface{}, error)
 
-	// AsXml returns an annotated structure that can be serialized to XML
-	AsXML() interface{}
+	// AsXML returns an annotated structure that can be serialized to XML. ErrNotImplemented is returned if the operation is not implemented
+	AsXML() (interface{}, error)
 
-	// AsTemplate returns a structure that can be serialized via template
-	AsTemplate() interface{}
+	// AsTemplate returns a structure that can be serialized via template. ErrNotImplemented is returned if the operation is not implemented
+	AsTemplate() (interface{}, error)
 }
 
 // WrapVM wraps given vm in a RecordWrapper

--- a/consumer/wrapper/wrapper.go
+++ b/consumer/wrapper/wrapper.go
@@ -1,0 +1,35 @@
+package wrapper
+
+import (
+	"github.com/goat-project/goat-proto-go"
+)
+
+// RecordWrapper is an interface to wrap record types
+type RecordWrapper interface {
+	// Filename returns name of file this should be saved in WITHOUT extension
+	Filename() string
+
+	// AsJson returns an annotated structure that can be serialized to JSON
+	AsJSON() interface{}
+
+	// AsXml returns an annotated structure that can be serialized to XML
+	AsXML() interface{}
+
+	// AsTemplate returns a structure that can be serialized via template
+	AsTemplate() interface{}
+}
+
+// WrapVM wraps given vm in a RecordWrapper
+func WrapVM(vm goat_grpc.VmRecord) RecordWrapper {
+	return NewVMWrapper(vm)
+}
+
+// WrapIP wraps given ip in a RecordWrapper
+func WrapIP(ip goat_grpc.IpRecord) RecordWrapper {
+	return NewIPWrapper(ip)
+}
+
+// WrapStorage wraps given storage in a RecordWrapper
+func WrapStorage(st goat_grpc.StorageRecord) RecordWrapper {
+	return NewStorageWrapper(st)
+}


### PR DESCRIPTION
As we discussed, I've created wrapper structures for VM, IP and Storage that will provide ways of converting the GRPC objects into something that can be serialized to JSON, XML or as a template.

This PR also implements a wrapper object for VM that can be used to serialize VM as a template.