### PR TITLE
Merge consumer interfaces, adapt WriterConsumer

### DIFF
--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -5,20 +5,8 @@ import (
 	"github.com/goat-project/goat/consumer/wrapper"
 )
 
-// IPConsumer processes IpRecord-s
-type IPConsumer interface {
-	// ConsumeIps processes all ip records from specified channel and specified client id
-	ConsumeIps(ctx context.Context, id string, ips <-chan wrapper.RecordWrapper) (ResultsChannel, error)
-}
-
-// VMConsumer processes VmRecords
-type VMConsumer interface {
-	// ConsumeVMs processes all ip records from specified channel and specified client id
-	ConsumeVms(ctx context.Context, id string, vms <-chan wrapper.RecordWrapper) (ResultsChannel, error)
-}
-
-// StorageConsumer processes StorageRecords
-type StorageConsumer interface {
-	// ConsumeIps processes all ip records from specified channel and specified client id
-	ConsumeStorages(ctx context.Context, id string, sts <-chan wrapper.RecordWrapper) (ResultsChannel, error)
+// Consumer processes records
+type Consumer interface {
+	// Consume processes all records from specified channel and specified client id
+	Consume(ctx context.Context, id string, records <-chan wrapper.RecordWrapper) (ResultsChannel, error)
 }

--- a/consumer/consumer.go
+++ b/consumer/consumer.go
@@ -2,23 +2,23 @@ package consumer
 
 import (
 	"context"
-	"github.com/goat-project/goat-proto-go"
+	"github.com/goat-project/goat/consumer/wrapper"
 )
 
 // IPConsumer processes IpRecord-s
 type IPConsumer interface {
 	// ConsumeIps processes all ip records from specified channel and specified client id
-	ConsumeIps(ctx context.Context, id string, ips <-chan goat_grpc.IpRecord) (ResultsChannel, error)
+	ConsumeIps(ctx context.Context, id string, ips <-chan wrapper.RecordWrapper) (ResultsChannel, error)
 }
 
 // VMConsumer processes VmRecords
 type VMConsumer interface {
 	// ConsumeVMs processes all ip records from specified channel and specified client id
-	ConsumeVms(ctx context.Context, id string, vms <-chan goat_grpc.VmRecord) (ResultsChannel, error)
+	ConsumeVms(ctx context.Context, id string, vms <-chan wrapper.RecordWrapper) (ResultsChannel, error)
 }
 
 // StorageConsumer processes StorageRecords
 type StorageConsumer interface {
 	// ConsumeIps processes all ip records from specified channel and specified client id
-	ConsumeStorages(ctx context.Context, id string, sts <-chan goat_grpc.StorageRecord) (ResultsChannel, error)
+	ConsumeStorages(ctx context.Context, id string, sts <-chan wrapper.RecordWrapper) (ResultsChannel, error)
 }

--- a/consumer/writer.go
+++ b/consumer/writer.go
@@ -2,7 +2,7 @@ package consumer
 
 import (
 	"context"
-	"github.com/goat-project/goat-proto-go"
+	"github.com/goat-project/goat/consumer/wrapper"
 )
 
 // WriterConsumer processes accounting data by transforming them according to supplied templates and subsequently writing to a file
@@ -19,20 +19,8 @@ func NewWriter(dir, templatesDir string) WriterConsumer {
 	}
 }
 
-// ConsumeIps transforms IpRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each IpRecord is written to its own file.
-func (wc WriterConsumer) ConsumeIps(ctx context.Context, id string, ips <-chan goat_grpc.IpRecord) (ResultsChannel, error) {
-	res := make(chan Result)
-	return res, nil
-}
-
-// ConsumeVms transforms VmRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each VmRecord is written to its own file.
-func (wc WriterConsumer) ConsumeVms(ctx context.Context, id string, vms <-chan goat_grpc.VmRecord) (ResultsChannel, error) {
-	res := make(chan Result)
-	return res, nil
-}
-
-// ConsumeStorages transforms StorageRecord-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each StorageRecord is written to its own file.
-func (wc WriterConsumer) ConsumeStorages(ctx context.Context, id string, sts <-chan goat_grpc.StorageRecord) (ResultsChannel, error) {
+// Consume transforms Record-s into text and writes them to a subdirectory of dir specified by WriterConsumer's dir field. Each IpRecord is written to its own file.
+func (wc WriterConsumer) Consume(ctx context.Context, id string, records <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
 	res := make(chan Result)
 	return res, nil
 }

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/goat-project/goat-proto-go"
 	"github.com/goat-project/goat/consumer"
+	"github.com/goat-project/goat/consumer/wrapper"
 	"github.com/golang/protobuf/ptypes/empty"
 	"io"
 )
@@ -59,9 +60,9 @@ func (asi AccountingServiceImpl) Process(stream goat_grpc.AccountingService_Proc
 	defer cancelConsumers()
 
 	// prepare channels for individual data types
-	vms := make(chan goat_grpc.VmRecord)
-	ips := make(chan goat_grpc.IpRecord)
-	storages := make(chan goat_grpc.StorageRecord)
+	vms := make(chan wrapper.RecordWrapper)
+	ips := make(chan wrapper.RecordWrapper)
+	storages := make(chan wrapper.RecordWrapper)
 
 	results1, err := asi.vmConsumer.ConsumeVms(consumerContext, id, vms)
 	if err != nil {
@@ -100,11 +101,11 @@ func (asi AccountingServiceImpl) Process(stream goat_grpc.AccountingService_Proc
 		case *goat_grpc.AccountingData_Identifier:
 			return ErrNonFirstClientIdentifier
 		case *goat_grpc.AccountingData_Vm:
-			vms <- *data.GetVm()
+			vms <- wrapper.WrapVM(*data.GetVm())
 		case *goat_grpc.AccountingData_Ip:
-			ips <- *data.GetIp()
+			ips <- wrapper.WrapIP(*data.GetIp())
 		case *goat_grpc.AccountingData_Storage:
-			storages <- *data.GetStorage()
+			storages <- wrapper.WrapStorage(*data.GetStorage())
 		default:
 			return ErrUnknownMessageType
 		}

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -21,13 +21,13 @@ var (
 
 // AccountingServiceImpl implements goat_grpc.AccountingService server
 type AccountingServiceImpl struct {
-	vmConsumer      consumer.VMConsumer
-	ipConsumer      consumer.IPConsumer
-	storageConsumer consumer.StorageConsumer
+	vmConsumer      consumer.Consumer
+	ipConsumer      consumer.Consumer
+	storageConsumer consumer.Consumer
 }
 
 // NewAccountingServiceImpl creates a grpc server that sends received data to given channels and uses clientIdentifierValidator to validate client identifiers
-func NewAccountingServiceImpl(vmConsumer consumer.VMConsumer, ipConsumer consumer.IPConsumer, storageConsumer consumer.StorageConsumer) AccountingServiceImpl {
+func NewAccountingServiceImpl(vmConsumer consumer.Consumer, ipConsumer consumer.Consumer, storageConsumer consumer.Consumer) AccountingServiceImpl {
 	return AccountingServiceImpl{
 		vmConsumer:      vmConsumer,
 		ipConsumer:      ipConsumer,
@@ -64,17 +64,17 @@ func (asi AccountingServiceImpl) Process(stream goat_grpc.AccountingService_Proc
 	ips := make(chan wrapper.RecordWrapper)
 	storages := make(chan wrapper.RecordWrapper)
 
-	results1, err := asi.vmConsumer.ConsumeVms(consumerContext, id, vms)
+	results1, err := asi.vmConsumer.Consume(consumerContext, id, vms)
 	if err != nil {
 		return err
 	}
 
-	results2, err := asi.ipConsumer.ConsumeIps(consumerContext, id, ips)
+	results2, err := asi.ipConsumer.Consume(consumerContext, id, ips)
 	if err != nil {
 		return err
 	}
 
-	results3, err := asi.storageConsumer.ConsumeStorages(consumerContext, id, storages)
+	results3, err := asi.storageConsumer.Consume(consumerContext, id, storages)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR merges interfaces of different consumer into single interface using wrappers structures. WriterConsumer skeleton is then adapted to the new interface. Importer is also adapted to both wrapper structures and new Consumer concept.