### PR TITLE
Introduce RecordStream

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -120,6 +120,7 @@
   analyzer-version = 1
   input-imports = [
     "github.com/goat-project/goat-proto-go",
+    "github.com/golang/protobuf/ptypes/empty",
     "github.com/golang/protobuf/ptypes/wrappers",
     "google.golang.org/grpc",
     "google.golang.org/grpc/credentials",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,11 +3,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:9e1960a3af770966349b91d00e58aae3725646a821b52a47702e601532d1de57"
+  digest = "1:30e90851c7306f8243916c401e18a8535cbfc1f11e34d75f0243602f4191ba53"
   name = "github.com/goat-project/goat-proto-go"
   packages = ["."]
   pruneopts = ""
-  revision = "268c1c161c790c20484a5367564c3ddfa3b572f4"
+  revision = "f24ada67b5ee93ea6aa3233f018a1e7dfa0ef89c"
 
 [[projects]]
   digest = "1:3dd078fda7500c341bc26cfbc6c6a34614f295a2457149fc1045cab767cbcf18"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -120,7 +120,6 @@
   analyzer-version = 1
   input-imports = [
     "github.com/goat-project/goat-proto-go",
-    "github.com/golang/protobuf/ptypes/empty",
     "github.com/golang/protobuf/ptypes/wrappers",
     "google.golang.org/grpc",
     "google.golang.org/grpc/credentials",

--- a/importer/grpc_wrapper.go
+++ b/importer/grpc_wrapper.go
@@ -1,0 +1,91 @@
+package importer
+
+import (
+	"github.com/goat-project/goat-proto-go"
+	"github.com/goat-project/goat/consumer/wrapper"
+	"github.com/golang/protobuf/ptypes/empty"
+)
+
+var (
+	emptyMessage = empty.Empty{}
+)
+
+// WrapVms wraps GRPC stream of VMs in a RecordStream
+func WrapVms(vms goat_grpc.AccountingService_ProcessVmsServer) RecordStream {
+	return grpcStreamWrapper{stream: vms.(grpcStream)}
+}
+
+// WrapIps wraps GRPC stream of IPs in a RecordStream
+func WrapIps(ips goat_grpc.AccountingService_ProcessIpsServer) RecordStream {
+	return grpcStreamWrapper{stream: ips.(grpcStream)}
+}
+
+// WrapStorages wraps GRPC stream of Storage records in a RecordStream
+func WrapStorages(storages goat_grpc.AccountingService_ProcessStoragesServer) RecordStream {
+	return grpcStreamWrapper{stream: storages.(grpcStream)}
+}
+
+type identifiable interface {
+	GetIdentifier() string
+}
+
+type grpcStream interface {
+	Recv() (identifiable, error)
+	SendAndClose(*empty.Empty) error
+}
+
+type grpcStreamWrapper struct {
+	stream grpcStream
+}
+
+func (gsw grpcStreamWrapper) ReceiveIdentifier() (string, error) {
+	identifiable, err := gsw.stream.Recv()
+	if err != nil {
+		return "", err
+	}
+
+	identifier := identifiable.GetIdentifier()
+	if identifier == "" {
+		return "", ErrFirstClientIdentifier
+	}
+
+	return identifier, nil
+}
+
+func (gsw grpcStreamWrapper) Receive() (wrapper.RecordWrapper, error) {
+	identifiable, err := gsw.stream.Recv()
+
+	if err != nil {
+		return nil, err
+	}
+
+	switch identifiable.(type) {
+	case *goat_grpc.IpData:
+		ipd := identifiable.(*goat_grpc.IpData).GetIp()
+		if ipd == nil {
+			return nil, ErrNonFirstClientIdentifier
+		}
+
+		return wrapper.WrapIP(*ipd), nil
+	case *goat_grpc.VmData:
+		vmd := identifiable.(*goat_grpc.VmData).GetVm()
+		if vmd == nil {
+			return nil, ErrNonFirstClientIdentifier
+		}
+
+		return wrapper.WrapVM(*vmd), nil
+	case *goat_grpc.StorageData:
+		std := identifiable.(*goat_grpc.StorageData).GetStorage()
+		if std == nil {
+			return nil, ErrNonFirstClientIdentifier
+		}
+
+		return wrapper.WrapStorage(*std), nil
+	default:
+		return nil, ErrUnknownMessageType
+	}
+}
+
+func (gsw grpcStreamWrapper) Close() error {
+	return gsw.stream.SendAndClose(&emptyMessage)
+}

--- a/importer/grpc_wrapper.go
+++ b/importer/grpc_wrapper.go
@@ -53,29 +53,29 @@ func (gsw grpcStreamWrapper) ReceiveIdentifier() (string, error) {
 }
 
 func (gsw grpcStreamWrapper) Receive() (wrapper.RecordWrapper, error) {
-	identifiable, err := gsw.stream.Recv()
+	data, err := gsw.stream.Recv()
 
 	if err != nil {
 		return nil, err
 	}
 
-	switch identifiable.(type) {
+	switch data.(type) {
 	case *goat_grpc.IpData:
-		ipd := identifiable.(*goat_grpc.IpData).GetIp()
+		ipd := data.(*goat_grpc.IpData).GetIp()
 		if ipd == nil {
 			return nil, ErrNonFirstClientIdentifier
 		}
 
 		return wrapper.WrapIP(*ipd), nil
 	case *goat_grpc.VmData:
-		vmd := identifiable.(*goat_grpc.VmData).GetVm()
+		vmd := data.(*goat_grpc.VmData).GetVm()
 		if vmd == nil {
 			return nil, ErrNonFirstClientIdentifier
 		}
 
 		return wrapper.WrapVM(*vmd), nil
 	case *goat_grpc.StorageData:
-		std := identifiable.(*goat_grpc.StorageData).GetStorage()
+		std := data.(*goat_grpc.StorageData).GetStorage()
 		if std == nil {
 			return nil, ErrNonFirstClientIdentifier
 		}

--- a/importer/importer.go
+++ b/importer/importer.go
@@ -85,7 +85,17 @@ func (asi AccountingServiceImpl) processStream(stream RecordStream, consumer con
 	}
 }
 
-// Process is a GRPC call -- do not use
-func (asi AccountingServiceImpl) Process(stream goat_grpc.AccountingService_ProcessServer) error {
-	return asi.processStream(WrapGrpc(stream), asi.vmConsumer)
+// ProcessVms is a GRPC call -- do not use
+func (asi AccountingServiceImpl) ProcessVms(vms goat_grpc.AccountingService_ProcessVmsServer) error {
+	return asi.processStream(WrapVms(vms), asi.vmConsumer)
+}
+
+// ProcessIps is a GRPC call -- do not use
+func (asi AccountingServiceImpl) ProcessIps(ips goat_grpc.AccountingService_ProcessIpsServer) error {
+	return asi.processStream(WrapIps(ips), asi.ipConsumer)
+}
+
+// ProcessStorages is a GRPC call -- do not use
+func (asi AccountingServiceImpl) ProcessStorages(storages goat_grpc.AccountingService_ProcessStoragesServer) error {
+	return asi.processStream(WrapStorages(storages), asi.storageConsumer)
 }

--- a/importer/record_stream.go
+++ b/importer/record_stream.go
@@ -1,0 +1,24 @@
+package importer
+
+import (
+	"github.com/goat-project/goat-proto-go"
+	"github.com/goat-project/goat/consumer/wrapper"
+)
+
+// RecordStream is a stream of records
+type RecordStream interface {
+	// ReceiveIdentifier receives client identifier from given stream.
+	// If the first message is not client identifier, ErrNonFirstClientIdentifier is returned
+	ReceiveIdentifier() (string, error)
+	// Receive receives the next record from the stream.
+	// If there is no more records in the stream, io.EOF is returned.
+	Receive() (wrapper.RecordWrapper, error)
+	// Close closes the stream
+	Close() error
+}
+
+// WrapGrpc wraps the GRPC stream using a RecordStream
+func WrapGrpc(stream goat_grpc.AccountingService_ProcessServer) RecordStream {
+	var rs RecordStream
+	return rs
+}

--- a/importer/record_stream.go
+++ b/importer/record_stream.go
@@ -1,24 +1,20 @@
 package importer
 
 import (
-	"github.com/goat-project/goat-proto-go"
 	"github.com/goat-project/goat/consumer/wrapper"
 )
 
-// RecordStream is a stream of records
+// RecordStream is a stream of records. ReceiveIdentifier must be called first, then Receive can be called
 type RecordStream interface {
 	// ReceiveIdentifier receives client identifier from given stream.
 	// If the first message is not client identifier, ErrNonFirstClientIdentifier is returned
 	ReceiveIdentifier() (string, error)
+
 	// Receive receives the next record from the stream.
 	// If there is no more records in the stream, io.EOF is returned.
+	// If an identifier is received, ErrNonFirstClientIdentifier is returned.
 	Receive() (wrapper.RecordWrapper, error)
+
 	// Close closes the stream
 	Close() error
-}
-
-// WrapGrpc wraps the GRPC stream using a RecordStream
-func WrapGrpc(stream goat_grpc.AccountingService_ProcessServer) RecordStream {
-	var rs RecordStream
-	return rs
 }


### PR DESCRIPTION
RecordStream wraps all types of GRPC streams in goat into a single type. Instead of providing access to concrete types, it provides access only to records. It'll be useful during testing, too. 

I had to try really hard to get around go's type system to avoid copy-pasting the error handling code and it ended up working somehow. The 'ugliest' part is definitely `grpcStreamWrapper`, so I'd be happy to hear if you have any concerns about it.