### PR TITLE
Implement TemplateGroupWriter

### DIFF
--- a/consumer/template_group_writer.go
+++ b/consumer/template_group_writer.go
@@ -1,0 +1,28 @@
+package consumer
+
+import (
+	"context"
+	"github.com/goat-project/goat/consumer/wrapper"
+)
+
+// TemplateGroupWriter converts each record to template and writes it to file. Multiple records may be written into a single file.
+type TemplateGroupWriter struct {
+	dir          string
+	templatesDir string
+	countPerFile uint64
+}
+
+// NewTemplateGroupWriter creates a new TemplateGroupWriter.
+func NewTemplateGroupWriter(dir, templatesDir string, countPerFile uint64) TemplateGroupWriter {
+	return TemplateGroupWriter{
+		dir:          dir,
+		templatesDir: templatesDir,
+		countPerFile: countPerFile,
+	}
+}
+
+// Consume converts each record to template and writes it to file. Multiple records may be written into a single file.
+func (wc TemplateGroupWriter) Consume(ctx context.Context, id string, records <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
+	res := make(chan Result)
+	return res, nil
+}

--- a/consumer/template_group_writer.go
+++ b/consumer/template_group_writer.go
@@ -21,7 +21,7 @@ type vmsTemplateData struct {
 
 // TemplateGroupWriter converts each record to template and writes it to file. Multiple records may be written into a single file.
 type TemplateGroupWriter struct {
-	dir          string
+	outputDir    string
 	templatesDir string
 	countPerFile uint64
 	templateName string
@@ -30,9 +30,9 @@ type TemplateGroupWriter struct {
 }
 
 // NewTemplateGroupWriter creates a new TemplateGroupWriter.
-func NewTemplateGroupWriter(dir, templatesDir, templateName string, countPerFile uint64) TemplateGroupWriter {
+func NewTemplateGroupWriter(outputDir, templatesDir, templateName string, countPerFile uint64) TemplateGroupWriter {
 	return TemplateGroupWriter{
-		dir:          dir,
+		outputDir:    outputDir,
 		templatesDir: templatesDir,
 		countPerFile: countPerFile,
 		templateName: templateName,
@@ -94,7 +94,7 @@ func writeFile(data interface{}, recordCount uint64, template *template.Template
 func (tgw TemplateGroupWriter) Consume(ctx context.Context, id string, records <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
 	res := make(chan Result)
 
-	if err := ensureDirectoryExists(path.Join(tgw.dir, id)); err != nil {
+	if err := ensureDirectoryExists(path.Join(tgw.outputDir, id)); err != nil {
 		return nil, err
 	}
 
@@ -116,7 +116,7 @@ func (tgw TemplateGroupWriter) Consume(ctx context.Context, id string, records <
 					if countInFile > 0 {
 						// but we have something to save!
 						templateData := vmsTemplateData{Vms: tgw.records}
-						err := writeFile(templateData, countInFile, tgw.template, path.Join(tgw.dir, path.Join(id, fmt.Sprintf(filenameFormat, filenameCounter))), tgw.templateName)
+						err := writeFile(templateData, countInFile, tgw.template, path.Join(tgw.outputDir, path.Join(id, fmt.Sprintf(filenameFormat, filenameCounter))), tgw.templateName)
 						if err != nil {
 							trySendError(ctx, res, err)
 						}
@@ -138,7 +138,7 @@ func (tgw TemplateGroupWriter) Consume(ctx context.Context, id string, records <
 				// if we already have this many records in the file
 				if countInFile == tgw.countPerFile {
 					templateData := vmsTemplateData{Vms: tgw.records}
-					err = writeFile(templateData, countInFile, tgw.template, path.Join(tgw.dir, path.Join(id, fmt.Sprintf(filenameFormat, filenameCounter))), tgw.templateName)
+					err = writeFile(templateData, countInFile, tgw.template, path.Join(tgw.outputDir, path.Join(id, fmt.Sprintf(filenameFormat, filenameCounter))), tgw.templateName)
 					if err != nil {
 						trySendError(ctx, res, err)
 					}

--- a/consumer/template_group_writer.go
+++ b/consumer/template_group_writer.go
@@ -73,7 +73,9 @@ func trySendError(ctx context.Context, res chan<- Result, err error) {
 }
 
 func (tgw TemplateGroupWriter) writeFile(id string, countInFile, filenameCounter uint64) error {
-	templateData := vmsTemplateData{Vms: tgw.records}
+	newRecords := make([]interface{}, countInFile)
+	copy(newRecords, tgw.records)
+	templateData := vmsTemplateData{Vms: newRecords}
 	filename := path.Join(tgw.outputDir, path.Join(id, fmt.Sprintf(filenameFormat, filenameCounter)))
 	// open the file
 	file, err := os.Create(filename)

--- a/consumer/template_group_writer.go
+++ b/consumer/template_group_writer.go
@@ -20,7 +20,8 @@ type vmsTemplateData struct {
 	Vms []interface{}
 }
 
-// TemplateGroupWriter converts each record to template and writes it to file. Multiple records may be written into a single file.
+// TemplateGroupWriter converts each record to template and writes it to file.
+// Multiple records may be written into a single file.
 type TemplateGroupWriter struct {
 	outputDir    string
 	templatesDir string
@@ -93,8 +94,10 @@ func (tgw TemplateGroupWriter) writeFile(id string, countInFile, filenameCounter
 	return file.Close()
 }
 
-// Consume converts each record to template and writes it to file. Multiple records may be written into a single file.
-func (tgw TemplateGroupWriter) Consume(ctx context.Context, id string, records <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
+// Consume converts each record to template and writes it to file.
+// Multiple records may be written into a single file.
+func (tgw TemplateGroupWriter) Consume(ctx context.Context, id string,
+	records <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
 	res := make(chan Result)
 
 	if err := ensureDirectoryExists(path.Join(tgw.outputDir, id)); err != nil {

--- a/consumer/template_group_writer.go
+++ b/consumer/template_group_writer.go
@@ -2,7 +2,16 @@ package consumer
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"path"
+	"text/template"
+
 	"github.com/goat-project/goat/consumer/wrapper"
+)
+
+const (
+	templateFileExtension = "tmpl"
 )
 
 // TemplateGroupWriter converts each record to template and writes it to file. Multiple records may be written into a single file.
@@ -10,19 +19,132 @@ type TemplateGroupWriter struct {
 	dir          string
 	templatesDir string
 	countPerFile uint64
+	templateName string
+	outExtension string
+	template     *template.Template
 }
 
 // NewTemplateGroupWriter creates a new TemplateGroupWriter.
-func NewTemplateGroupWriter(dir, templatesDir string, countPerFile uint64) TemplateGroupWriter {
+func NewTemplateGroupWriter(dir, templatesDir, templateName, outExtension string, countPerFile uint64) TemplateGroupWriter {
 	return TemplateGroupWriter{
 		dir:          dir,
 		templatesDir: templatesDir,
 		countPerFile: countPerFile,
+		templateName: templateName,
+		outExtension: outExtension,
+		template:     nil,
+	}
+}
+
+func ensureDirectoryExists(path string) error {
+	err := os.MkdirAll(path, os.ModePerm)
+	if err != nil && err != os.ErrExist {
+		return err
+	}
+
+	return nil
+}
+
+func (tgw *TemplateGroupWriter) initTemplate() error {
+	if tgw.template != nil {
+		return nil
+	}
+
+	template, err := template.ParseGlob(path.Join(tgw.templatesDir, fmt.Sprintf("*.%s", templateFileExtension)))
+	tgw.template = template
+	return err
+}
+
+func trySendError(ctx context.Context, res chan<- Result, err error) {
+	for {
+		select {
+		case res <- NewErrorResult(err):
+			// error sent successfully
+			return
+		case <-ctx.Done():
+			// goroutine has been canceled
+			return
+		}
 	}
 }
 
 // Consume converts each record to template and writes it to file. Multiple records may be written into a single file.
-func (wc TemplateGroupWriter) Consume(ctx context.Context, id string, records <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
+func (tgw TemplateGroupWriter) Consume(ctx context.Context, id string, records <-chan wrapper.RecordWrapper) (ResultsChannel, error) {
 	res := make(chan Result)
+
+	if err := ensureDirectoryExists(path.Join(tgw.dir, id)); err != nil {
+		return nil, err
+	}
+
+	if err := tgw.initTemplate(); err != nil {
+		return nil, err
+	}
+
+	// open the initial file
+	file, err := os.Create(path.Join(tgw.dir, path.Join(id, fmt.Sprintf("0.%s", tgw.outExtension))))
+	if err != nil {
+		return nil, err
+	}
+
+	go func() {
+
+		defer func() {
+			err := file.Close()
+			trySendError(ctx, res, err)
+
+			// res must be closed after the file, as it might be used to send the last error
+			close(res)
+		}()
+
+		var countInFile, filenameCounter uint64
+		countInFile, filenameCounter = 0, 0
+		for {
+			select {
+			case templateData, ok := <-records:
+				if !ok {
+					// end of stream
+					return
+				}
+				// write templateData to file
+				err := tgw.template.ExecuteTemplate(file, tgw.templateName, templateData)
+				if err != nil {
+					trySendError(ctx, res, err)
+					return
+				}
+
+				countInFile++
+
+				// if we already have this many records in the file
+				if countInFile == tgw.countPerFile {
+
+					// close file
+					err = file.Close()
+					if err != nil {
+						trySendError(ctx, res, err)
+						// exit on error
+						return
+					}
+
+					// increase filename counter
+					filenameCounter++
+
+					// open next file
+					file, err = os.Create(path.Join(tgw.dir, path.Join(id, fmt.Sprintf("%d.%s", filenameCounter, tgw.outExtension))))
+					if err != nil {
+						trySendError(ctx, res, err)
+						// exit on error
+						return
+					}
+
+					// reset record in file counter
+					countInFile = 0
+				}
+			case <-ctx.Done():
+				// goroutine has been canceled
+				return
+			}
+		}
+	}()
+
 	return res, nil
 }

--- a/consumer/wrapper/vm_wrapper.go
+++ b/consumer/wrapper/vm_wrapper.go
@@ -12,6 +12,8 @@ type vmWrapper struct {
 }
 
 type vmTemplate struct {
+	// naming of these fields must be consistent with vm.tmpl
+
 	VMUUID              string
 	SiteName            string
 	CloudComputeService *string

--- a/goat.go
+++ b/goat.go
@@ -17,6 +17,7 @@ var (
 	keyFile      = flag.String("key-file", "server.key", "server key file")
 	outDir       = flag.String("out-dir", "", "output directory")
 	templatesDir = flag.String("templates-dir", "", "templates directory")
+	vmPerFile    = flag.Uint64("vm-per-file", 500, "number of VMs per template file")
 )
 
 func checkArgs() error {
@@ -49,7 +50,7 @@ func main() {
 		return
 	}
 
-	err = service.Serve(ip, port, tls, certFile, keyFile, outDir, templatesDir)
+	err = service.Serve(ip, port, tls, certFile, keyFile, outDir, templatesDir, vmPerFile)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -35,7 +35,7 @@ func Serve(ip *string, port *uint, tls *bool, certFile *string, keyFile *string,
 
 	grpcServer := grpc.NewServer(opts...)
 
-	wr := consumer.NewTemplateGroupWriter(*outDir, *templatesDir, "VMS", vmPerFile)
+	wr := consumer.NewTemplateGroupWriter(*outDir, *templatesDir, vmPerFile)
 	goat_grpc.RegisterAccountingServiceServer(grpcServer, importer.NewAccountingServiceImpl(wr, wr, wr))
 
 	return grpcServer.Serve(server)

--- a/service/service.go
+++ b/service/service.go
@@ -35,7 +35,7 @@ func Serve(ip *string, port *uint, tls *bool, certFile *string, keyFile *string,
 
 	grpcServer := grpc.NewServer(opts...)
 
-	wr := consumer.NewTemplateGroupWriter(*outDir, *templatesDir, "VM", "apel", vmPerFile)
+	wr := consumer.NewTemplateGroupWriter(*outDir, *templatesDir, "VMS", vmPerFile)
 	goat_grpc.RegisterAccountingServiceServer(grpcServer, importer.NewAccountingServiceImpl(wr, wr, wr))
 
 	return grpcServer.Serve(server)

--- a/service/service.go
+++ b/service/service.go
@@ -35,7 +35,7 @@ func Serve(ip *string, port *uint, tls *bool, certFile *string, keyFile *string,
 
 	grpcServer := grpc.NewServer(opts...)
 
-	wr := consumer.NewTemplateGroupWriter(*outDir, *templatesDir, vmPerFile)
+	wr := consumer.NewTemplateGroupWriter(*outDir, *templatesDir, "VM", "apel", vmPerFile)
 	goat_grpc.RegisterAccountingServiceServer(grpcServer, importer.NewAccountingServiceImpl(wr, wr, wr))
 
 	return grpcServer.Serve(server)

--- a/service/service.go
+++ b/service/service.go
@@ -11,6 +11,10 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
+const (
+	vmPerFile = 500
+)
+
 // Serve starts grpc server on ip:port, optionally using tls. If *tls == true, then *certFile and
 // *keyFile must be != null
 func Serve(ip *string, port *uint, tls *bool, certFile *string, keyFile *string, outDir *string,
@@ -31,7 +35,7 @@ func Serve(ip *string, port *uint, tls *bool, certFile *string, keyFile *string,
 
 	grpcServer := grpc.NewServer(opts...)
 
-	wr := consumer.NewWriter(*outDir, *templatesDir)
+	wr := consumer.NewTemplateGroupWriter(*outDir, *templatesDir, vmPerFile)
 	goat_grpc.RegisterAccountingServiceServer(grpcServer, importer.NewAccountingServiceImpl(wr, wr, wr))
 
 	return grpcServer.Serve(server)

--- a/service/service.go
+++ b/service/service.go
@@ -11,14 +11,10 @@ import (
 	"google.golang.org/grpc/credentials"
 )
 
-const (
-	vmPerFile = 500
-)
-
 // Serve starts grpc server on ip:port, optionally using tls. If *tls == true, then *certFile and
 // *keyFile must be != null
 func Serve(ip *string, port *uint, tls *bool, certFile *string, keyFile *string, outDir *string,
-	templatesDir *string) error {
+	templatesDir *string, vmPerFile *uint64) error {
 	server, err := net.Listen("tcp", fmt.Sprintf("%s:%d", *ip, *port))
 	if err != nil {
 		return err
@@ -35,7 +31,7 @@ func Serve(ip *string, port *uint, tls *bool, certFile *string, keyFile *string,
 
 	grpcServer := grpc.NewServer(opts...)
 
-	wr := consumer.NewTemplateGroupWriter(*outDir, *templatesDir, vmPerFile)
+	wr := consumer.NewTemplateGroupWriter(*outDir, *templatesDir, *vmPerFile)
 	goat_grpc.RegisterAccountingServiceServer(grpcServer, importer.NewAccountingServiceImpl(wr, wr, wr))
 
 	return grpcServer.Serve(server)

--- a/templates/vm.tmpl
+++ b/templates/vm.tmpl
@@ -1,0 +1,34 @@
+{{define "optional"}}
+{{if .}} {{.}} {{else}} NULL {{end}}
+{{end}}
+
+{{define "VM"}}
+APEL-cloud-message: v0.4
+VMUUID: {{.VMUUID}}
+SiteName: {{.SiteName}}
+CloudComputeService: {{template "optional" .CloudComputeService}}
+MachineName: {{template "optional" .MachineName}}
+LocalUserId: {{template "optional" .LocalUserID}}
+LocalGroupId: {{template "optional" .LocalGroupID}}
+GlobalUserName: {{.GlobalUserName}}
+FQAN: {{template "optional" .Fqan}}
+Status: {{template "optional" .Status}}
+StartTime: {{.StartTime}}
+EndTime: {{template "optional" .EndTime}}
+SuspendDuration: {{template "optional" .SuspendDuration}}
+WallDuration: {{template "optional" .WallDuration}}
+CpuDuration: {{template "optional" .CPUDuration}}
+CpuCount: {{template "optional" .CPUCount}}
+NetworkType: {{template "optional" .NetworkType}}
+NetworkInbound: {{template "optional" .NetworkInbound}}
+NetworkOutbound: {{template "optional" .NetworkOutbound}}
+PublicIPCount: {{template "optional" .PublicIPCount}}
+Memory: {{template "optional" .Memory}}
+Disk: {{template "optional" .Disk}}
+StorageRecordId: {{template "optional" .StorageRecordID}}
+ImageId: {{template "optional" .ImageID}}
+CloudType: {{.CloudType}}
+BenchmarkType: {{template "optional" .BenchmarkType}}
+Benchmark: {{template "optional" .Benchmark}}
+%%
+{{end}}

--- a/templates/vm.tmpl
+++ b/templates/vm.tmpl
@@ -34,5 +34,5 @@ Benchmark: {{template "optional" .Benchmark}}
 
 {{define "VMS"}}
 APEL-cloud-message: v0.4
-{{range vms}} VM {{end}}
+{{range .Vms}} {{template "VM" .}} {{end}}
 {{end}}

--- a/templates/vm.tmpl
+++ b/templates/vm.tmpl
@@ -3,7 +3,6 @@
 {{end}}
 
 {{define "VM"}}
-APEL-cloud-message: v0.4
 VMUUID: {{.VMUUID}}
 SiteName: {{.SiteName}}
 CloudComputeService: {{template "optional" .CloudComputeService}}
@@ -31,4 +30,9 @@ CloudType: {{.CloudType}}
 BenchmarkType: {{template "optional" .BenchmarkType}}
 Benchmark: {{template "optional" .Benchmark}}
 %%
+{{end}}
+
+{{define "VMS"}}
+APEL-cloud-message: v0.4
+{{range vms}} VM {{end}}
 {{end}}


### PR DESCRIPTION
`TemplateGroupWriter` is a type of consumer that:
1. receives record from a `RecordChannel`
2. transforms the record into template
3. writes the result into a file

It is a "Group" writer, because multiple records can be written into the same file (count is configurable).  This type of consumer will be used for VMs. 

The only thing missing (and the reason this PR is WIP) is the template file for the VM. I'll write it before the end of weekend, ideally tomorrow. I just wanted you to have a look at the code in the meanwhile.